### PR TITLE
Fix nav-toggle bug when resizing the browser

### DIFF
--- a/js/scripts.js
+++ b/js/scripts.js
@@ -9,8 +9,8 @@ $navToggle.on('click', function() {
 });
 
 $window.on('resize', function() {
-  if ($window.width() > mobileBreakpoint) {
-    $mainNavUl.show();
-    $navToggle.addClass('active');
+  if ($window.width() > mobileBreakpoint && $mainNavUl.is(':hidden')) {
+    $mainNavUl.removeAttr('style');
+    $navToggle.removeClass('active');
   }
 });


### PR DESCRIPTION
If window width is greater than `767` && if `.main-nav ul` is hidden, remove style attribute & active class
